### PR TITLE
Build the server and run it

### DIFF
--- a/server/app.js
+++ b/server/app.js
@@ -1,0 +1,12 @@
+const express = require('express');
+
+const app = express();
+
+app.disable('x-powered-by');
+app.use(express.json());
+app.use(express.urlencoded({ extended: false }));
+
+app.set('port', process.env.PORT || 5000);
+
+
+module.exports = app;

--- a/server/index.js
+++ b/server/index.js
@@ -1,0 +1,7 @@
+const app = require('./app');
+
+
+app.listen(app.get('port'), () => {
+  // eslint-disable-next-line no-console
+  console.log(`server is running on http://localhost:${app.get('port')}`);
+});


### PR DESCRIPTION
Relates #3
* I build an express server on port 5000, run it and it worked perfectly.
* I used `express.json()` and `express.urlencoded({ extended: false })`.
* I disabled `x-powered-by` message.